### PR TITLE
Introduce capital blackboard bold, calligraphic and fraktur letters

### DIFF
--- a/jlcode.sty
+++ b/jlcode.sty
@@ -655,7 +655,7 @@ literate=
 {𝕍}{{\ucc{$\mathbb 𝕍$}}}{1}
 {𝕎}{{\ucc{$\mathbb 𝕎$}}}{1}
 {𝕏}{{\ucc{$\mathbb 𝕏$}}}{1}
-{𝕐}{\u{cc{$\mathbb 𝕐$}}}{1}
+{𝕐}{{\ucc{$\mathbb 𝕐$}}}{1}
 {ℤ}{{\ucc{$\mathbb ℤ$}}}{1}
 %
 % capital script
@@ -685,7 +685,7 @@ literate=
 {𝒲}{{\ucc{$\mathcal W$}}}{1}
 {𝒳}{{\ucc{$\mathcal X$}}}{1}
 {𝒴}{{\ucc{$\mathcal Y$}}}{1}
-{𝒵}{{\ucc{$\mathcal Z$}}}{1}%
+{𝒵}{{\ucc{$\mathcal Z$}}}{1}
 %
 % Capital Mathfrak
 %
@@ -714,7 +714,8 @@ literate=
 {𝔚}{{\ucc{$\mathfrak W$}}}{1}
 {𝔛}{{\ucc{$\mathfrak X$}}}{1}
 {𝔜}{{\ucc{$\mathfrak Y$}}}{1}
-{ℨ}{{\ucc{$\mathfrak Z$}}}{1}%
+{ℨ}{{\ucc{$\mathfrak Z$}}}{1}
+%
 % special characters that appear in latin languages
 %
 {á}{{\ucc{\'a}}}{1} {é}{{\ucc{\'e}}}{1} {í}{{\ucc{\'i}}}{1} {ó}{{\ucc{\'o}}}{1}

--- a/jlcode.sty
+++ b/jlcode.sty
@@ -629,6 +629,92 @@ opliterate=*
 extendedchars=true,
 literate=
 %
+% Capital blackboard bold letters
+%
+{𝔸}{{\ucc{$\mathbb A$}}}{1}
+{𝔹}{{\ucc{$\mathbb B$}}}{1}
+{ℂ}{{\ucc{$\mathbb C$}}}{1}
+{𝔻}{{\ucc{$\mathbb D$}}}{1}
+{𝔼}{{\ucc{$\mathbb E$}}}{1}
+{𝔽}{{\ucc{$\mathbb F$}}}{1}
+{𝔾}{{\ucc{$\mathbb 𝔾$}}}{1}
+{ℍ}{{\ucc{$\mathbb ℍ$}}}{1}
+{𝕀}{{\ucc{$\mathbb 𝕀$}}}{1}
+{𝕁}{{\ucc{$\mathbb 𝕁$}}}{1}
+{𝕂}{{\ucc{$\mathbb 𝕂$}}}{1}
+{𝕃}{{\ucc{$\mathbb 𝕃$}}}{1}
+{𝕄}{{\ucc{$\mathbb 𝕄$}}}{1}
+{ℕ}{{\ucc{$\mathbb ℕ$}}}{1}
+{𝕆}{{\ucc{$\mathbb 𝕆$}}}{1}
+{ℙ}{{\ucc{$\mathbb ℙ$}}}{1}
+{ℚ}{{\ucc{$\mathbb ℚ$}}}{1}
+{ℝ}{{\ucc{$\mathbb ℝ$}}}{1}
+{𝕊}{{\ucc{$\mathbb 𝕊$}}}{1}
+{𝕋}{{\ucc{$\mathbb 𝕋$}}}{1}
+{𝕌}{{\ucc{$\mathbb 𝕌$}}}{1}
+{𝕍}{{\ucc{$\mathbb 𝕍$}}}{1}
+{𝕎}{{\ucc{$\mathbb 𝕎$}}}{1}
+{𝕏}{{\ucc{$\mathbb 𝕏$}}}{1}
+{𝕐}{\u{cc{$\mathbb 𝕐$}}}{1}
+{ℤ}{{\ucc{$\mathbb ℤ$}}}{1}
+%
+% capital script
+%
+{𝒜}{{\ucc{$\mathcal A$}}}{1}
+{ℬ}{{\ucc{$\mathcal B$}}}{1}
+{𝒞}{{\ucc{$\mathcal C$}}}{1}
+{𝒟}{{\ucc{$\mathcal D$}}}{1}
+{ℰ}{{\ucc{$\mathcal E$}}}{1}
+{ℱ}{{\ucc{$\mathcal F$}}}{1}
+{𝒢}{{\ucc{$\mathcal G$}}}{1}
+{ℋ}{{\ucc{$\mathcal H$}}}{1}
+{ℐ}{{\ucc{$\mathcal I$}}}{1}
+{𝒥}{{\ucc{$\mathcal J$}}}{1}
+{𝒦}{{\ucc{$\mathcal K$}}}{1}
+{ℒ}{{\ucc{$\mathcal L$}}}{1}
+{ℳ}{{\ucc{$\mathcal M$}}}{1}
+{𝒩}{{\ucc{$\mathcal N$}}}{1}
+{𝒪}{{\ucc{$\mathcal O$}}}{1}
+{𝒫}{{\ucc{$\mathcal P$}}}{1}
+{𝒬}{{\ucc{$\mathcal Q$}}}{1}
+{ℛ}{{\ucc{$\mathcal R$}}}{1}
+{𝒮}{{\ucc{$\mathcal S$}}}{1}
+{𝒯}{{\ucc{$\mathcal T$}}}{1}
+{𝒰}{{\ucc{$\mathcal U$}}}{1}
+{𝒱}{{\ucc{$\mathcal V$}}}{1}
+{𝒲}{{\ucc{$\mathcal W$}}}{1}
+{𝒳}{{\ucc{$\mathcal X$}}}{1}
+{𝒴}{{\ucc{$\mathcal Y$}}}{1}
+{𝒵}{{\ucc{$\mathcal Z$}}}{1}%
+%
+% Capital Mathfrak
+%
+{𝔄}{{\ucc{$\mathfrak A$}}}{1}
+{𝔅}{{\ucc{$\mathfrak B$}}}{1}
+{ℭ}{{\ucc{$\mathfrak C$}}}{1}
+{𝔇}{{\ucc{$\mathfrak D$}}}{1}
+{𝔈}{{\ucc{$\mathfrak E$}}}{1}
+{𝔉}{{\ucc{$\mathfrak F$}}}{1}
+{𝔊}{{\ucc{$\mathfrak G$}}}{1}
+{ℌ}{{\ucc{$\mathfrak H$}}}{1}
+{ℑ}{{\ucc{$\mathfrak I$}}}{1}
+{𝔍}{{\ucc{$\mathfrak J$}}}{1}
+{𝔎}{{\ucc{$\mathfrak K$}}}{1}
+{𝔏}{{\ucc{$\mathfrak L$}}}{1}
+{𝔐}{{\ucc{$\mathfrak M$}}}{1}
+{𝔑}{{\ucc{$\mathfrak N$}}}{1}
+{𝔒}{{\ucc{$\mathfrak O$}}}{1}
+{𝔓}{{\ucc{$\mathfrak P$}}}{1}
+{𝔔}{{\ucc{$\mathfrak Q$}}}{1}
+{ℜ}{{\ucc{$\mathfrak R$}}}{1}
+{𝔖}{{\ucc{$\mathfrak S$}}}{1}
+{𝔗}{{\ucc{$\mathfrak T$}}}{1}
+{𝔘}{{\ucc{$\mathfrak U$}}}{1}
+{𝔙}{{\ucc{$\mathfrak V$}}}{1}
+{𝔚}{{\ucc{$\mathfrak W$}}}{1}
+{𝔛}{{\ucc{$\mathfrak X$}}}{1}
+{𝔜}{{\ucc{$\mathfrak Y$}}}{1}
+{ℨ}{{\ucc{$\mathfrak Z$}}}{1}%
 % special characters that appear in latin languages
 %
 {á}{{\ucc{\'a}}}{1} {é}{{\ucc{\'e}}}{1} {í}{{\ucc{\'i}}}{1} {ó}{{\ucc{\'o}}}{1}


### PR DESCRIPTION
Thanks for this comprehensive package. The nice list of unicode stuff is impressive and finally allows for Julia code to directly be pasted over.
I often use a few blackboard bold (double stroke) letters. Most prominently of course ℝ, ℂ, ℍ, and sometime 𝕂 as type parameters.Sometime I feel adventurous and even add calligraphic letters.
So I checked this table
https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols
and transferred also all freak letters. I know some math communities also prefer small frak letters, but for now they are not included here, yet.